### PR TITLE
Automatically create a file or smartly send the data to stdout when piped

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -16,7 +16,7 @@ const cli = meow(`
 	  $ echo "<h1>Unicorn</h1>" | capture-website
 
 	Options
-	  --output                 Image file path (writes it to stdout if omitted)
+	  --output                 Image file path (names file based on URL if omitted)
 	  --width                  Page width  [default: 1280]
 	  --height                 Page height  [default: 800]
 	  --type                   Image type: png|jpeg|webp  [default: png]
@@ -50,10 +50,12 @@ const cli = meow(`
 	  --inset                  Inset the screenshot relative to the viewport or \`--element\`. Accepts a number or four comma-separated numbers for top, right, left, and bottom.
 
 	Examples
-	  $ capture-website https://sindresorhus.com --output=screenshot.png
-	  $ capture-website index.html --output=screenshot.png
-	  $ echo "<h1>Unicorn</h1>" | capture-website --output=screenshot.png
-	  $ capture-website https://sindresorhus.com | open -f -a Preview
+    $ capture-website https://sindresorhus.com
+    $ capture-website https://sindresorhus.com --output=screenshot.png
+    $ capture-website index.html --output=screenshot.png
+    $ capture-website file:///tmp/index.html --full-page --output=-
+    $ echo "<h1>Unicorn</h1>" | capture-website --output=screenshot.png
+    $ capture-website https://sindresorhus.com | open -f -a Preview
 
 	Flag examples
 	  --output=screenshot.png

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
 		"capture-website": "^2.1.0",
 		"get-stdin": "^9.0.0",
 		"meow": "^10.1.1",
-		"split-on-first": "^3.0.0"
+		"split-on-first": "^3.0.0",
+		"filenamify": "^5.0.1"
 	},
 	"devDependencies": {
 		"ava": "^3.15.0",

--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,9 @@ You can run this:
 ```sh
 filename='urls.txt'
 
+< "$filename" xargs -I{} capture-website "{}"
+
+# Or, for custom output file naming
 while read url; do
   capture-website "$url" --output "screenshot-$(echo "$url" | sed -e 's/[^A-Za-z0-9._-]//g').png"
 done < "$filename"

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ $ capture-website --help
     $ echo "<h1>Unicorn</h1>" | capture-website
 
   Options
-    --output                 Image file path (writes it to stdout if omitted)
+    --output                 Image file path (names file based on URL if omitted)
     --width                  Page width  [default: 1280]
     --height                 Page height  [default: 800]
     --type                   Image type: png|jpeg|webp  [default: png]
@@ -56,8 +56,10 @@ $ capture-website --help
     --inset                  Inset the screenshot relative to the viewport or \`--element\`. Accepts a number or four comma-separated numbers for top, right, left, and bottom.
 
   Examples
+    $ capture-website https://sindresorhus.com
     $ capture-website https://sindresorhus.com --output=screenshot.png
     $ capture-website index.html --output=screenshot.png
+    $ capture-website file:///tmp/index.html --full-page --output=-
     $ echo "<h1>Unicorn</h1>" | capture-website --output=screenshot.png
     $ capture-website https://sindresorhus.com | open -f -a Preview
 


### PR DESCRIPTION

Hi there!

I've been using this little tool lately and I wanted to contribute with some user-friendly improvements:
- Automatically create a file named after the URL/file-path (closes #35) by default
- Or smartly send the data to stdout if the output is being piped
- Force the output to stdout with `--output -` following the POSIX conventions ([guideline 13](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html))
- Add some error handling and show concise error messages

In a nutshell:
```sh
$ capture-website https://github.com/git               # Auto-creates github.com-git.png in current dir

$ capture-website https://goo.gl | open -f -a Preview  # Automatically pipes the data

$ echo "<h1>Unicorn</h1>" | capture-website            # Auto-creates stdin.png

$ capture-website /path/to/file.html --type=jpeg       # Auto-creates file.jpeg

$ capture-website file:///path/to/file.html            # Auto-creates path-to-file.html.png

$ capture-website file.html --output test.png          # Auto-creates test.png

$ capture-website file.html --output=-                 # Send the data to stdout

$ capture-website http://i.dont/exist                  # Gracefully exits with an error message
```

Let me know what you think 😊