### PR TITLE
Fix multiple header values

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -166,6 +166,7 @@ const cli = meow(`
 		},
 		header: {
 			type: 'string',
+			isMultiple: true,
 		},
 		userAgent: {
 			type: 'string',


### PR DESCRIPTION
### Issue
As of now the `capture-website` command doesn't accepts multiple header parameters (but it is mentioned inside the `readme.md` file)
``` sh

> capture-website https://awesome-site.dev --header="X-Powered-By: Developers" --header="Custom-Header: Hello World!"

...
Error: The flag --header can only be set once.
    at validateFlags (file:///home/vins/.nvm/versions/node/v14.19.3/lib/node_modules/capture-website-cli/node_modules/meow/index.js:98:10)
    at meow (file:///home/vins/.nvm/versions/node/v14.19.3/lib/node_modules/capture-website-cli/node_modules/meow/index.js:224:2)
    at file:///home/vins/.nvm/versions/node/v14.19.3/lib/node_modules/capture-website-cli/cli.js:9:13

```

The error message clearly says that you cannot pass the `header` flag multiple times.

### PR Fix
This issue is due to the `flag` configuration that is not using the property `isMultiple: true`.
This PR simply adds this property to the flag configuration in order to make accptable multiple headers.